### PR TITLE
add Blogs & Posts page, restructure nav, fix Saylor link

### DIFF
--- a/src/components/common/Navbar.jsx
+++ b/src/components/common/Navbar.jsx
@@ -29,11 +29,12 @@ const Navbar = () => {
         { name: "Bitcoin Clubs", link: "/clubs" },
         { name: "Fellowship", link: "/fellowship" },
         { name: "Chaincode BOSS", link: "/chaincodeboss" },
+        { name: "Resources", link: "/resources" },
       ],
     },
     { name: "Bitspace", link: "/bitspace" },
     { name: "Meetups", link: "/meetups" },
-    { name: "Resources", link: "/resources" },
+    { name: "Blogs & Posts", link: "/blogs" },
   ];
 
   return (

--- a/src/components/common/hamburger.tsx
+++ b/src/components/common/hamburger.tsx
@@ -99,6 +99,7 @@ const SideMenu = () => {
         { name: "Bitcoin Clubs", link: "/clubs" },
         { name: "Fellowship", link: "/fellowship" },
         { name: "Chaincode BOSS", link: "/chaincodeboss" },
+        { name: "Resources", link: "/resources" },
       ],
     },
     {
@@ -114,8 +115,8 @@ const SideMenu = () => {
       subMenu: [],
     },
     {
-      name: "Resources",
-      link: "/resources",
+      name: "Blogs & Posts",
+      link: "/blogs",
       subMenu: [],
     },
   ];

--- a/src/pages/blogs.astro
+++ b/src/pages/blogs.astro
@@ -1,0 +1,193 @@
+---
+import Layout from "../layouts/Layout.astro";
+
+const headerProps = {
+  image: "/cohort/hero.webp",
+  removePadding: true,
+};
+const isVisible = true;
+
+const posts = [
+  {
+    title: "Coin Selection for Dummies: Part 5 — Waste Metric",
+    description:
+      "The waste metric heuristic — comparing UTXO selection sets by the cost of change, excess, and the fee difference between spending now versus later.",
+    link: "https://blog.summerofbitcoin.org/coin-selection-waste-metric/",
+    tag: "Coin Selection",
+    author: "Anmol Sharma",
+    date: "Aug 23, 2022",
+    source: "Summer of Bitcoin",
+  },
+  {
+    title: "Coin Selection for Dummies: Part 4 — Lowest Larger Selection",
+    description:
+      "Binary search applied to UTXO selection — pick the smallest UTXO greater than the target to minimize fees with minimal effort.",
+    link: "https://blog.summerofbitcoin.org/coin-selection-for-dummies-part-4-lowest-larger-selection/",
+    tag: "Coin Selection",
+    author: "Anmol Sharma",
+    date: "Aug 19, 2022",
+    source: "Summer of Bitcoin",
+  },
+  {
+    title: "Coin Selection for Dummies: Part 3 — Knapsack Solver",
+    description:
+      "Applying the classic knapsack problem to Bitcoin coin selection — multi-pass search for the smallest set of UTXOs that meets the spend target.",
+    link: "https://blog.summerofbitcoin.org/coin-selection-for-dummies-part-3/",
+    tag: "Coin Selection",
+    author: "Anmol Sharma",
+    date: "Aug 12, 2022",
+    source: "Summer of Bitcoin",
+  },
+  {
+    title: "Coin Selection for Dummies: Part 2 — Branch and Bound",
+    description:
+      "How the Branch and Bound algorithm systematically explores input combinations to find an exact match — no change output required.",
+    link: "https://blog.summerofbitcoin.org/coin-selection-for-dummies-2/",
+    tag: "Coin Selection",
+    author: "Anmol Sharma",
+    date: "Jul 14, 2022",
+    source: "Summer of Bitcoin",
+  },
+  {
+    title: "Coin Selection for Dummies: Part 1 — Overview",
+    description:
+      "How Bitcoin wallets pick UTXOs as inputs — the goals of coin selection (confirmation time, fees, privacy) and an overview of Bitcoin Core's approach.",
+    link: "https://blog.summerofbitcoin.org/coin-selection-part-1/",
+    tag: "Coin Selection",
+    author: "Anmol Sharma",
+    date: "Jun 24, 2022",
+    source: "Summer of Bitcoin",
+  },
+  {
+    title: "From \"Hello World\" to Bitcoin Core",
+    description:
+      "A guide to start your hike up the Bitcoin Hill — orientation for newcomers stepping into Bitcoin Core development.",
+    link: "https://medium.com/from-hello-world-to-bitcoin-core-dd233ce99f72",
+    tag: "Onboarding",
+    author: "Rajarshi Maitra",
+    date: "Jun 15, 2020",
+    source: "Medium",
+  },
+  {
+    title: "What The Heck is Script",
+    description:
+      "A deep dive into Bitcoin Script — the stack-based language behind Bitcoin's smart contracts.",
+    link: "https://medium.com/bitbees/what-the-heck-is-script-588c7ba061cd",
+    tag: "Script",
+    author: "Rajarshi Maitra",
+    date: "May 5, 2020",
+    source: "Medium",
+  },
+  {
+    title: "What The Heck is UTXO",
+    description:
+      "Peeking into the Bitcoin transaction structure to understand UTXOs — the building blocks of Bitcoin's state.",
+    link: "https://medium.com/bitbees/what-the-heck-is-utxo-ca68f2651819",
+    tag: "UTXO",
+    author: "Rajarshi Maitra",
+    date: "Apr 25, 2020",
+    source: "Medium",
+  },
+  {
+    title: "What The Heck is Schnorr",
+    description:
+      "On digital signatures and the magic of Schnorr — why it matters for Bitcoin and how it differs from ECDSA.",
+    link: "https://medium.com/bitbees/what-the-heck-is-schnorr-52ef5dba289f",
+    tag: "Schnorr",
+    author: "Rajarshi Maitra",
+    date: "Apr 21, 2020",
+    source: "Medium",
+  },
+  {
+    title: "What the Heck is SegWit",
+    description:
+      "The story, battle, and legacy of SegWit activation — what changed, why it mattered, and how it shaped Bitcoin.",
+    link: "https://medium.com/bitbees/what-the-heck-is-segwit-3f58b7352b1c",
+    tag: "SegWit",
+    author: "Rajarshi Maitra",
+    date: "Apr 10, 2020",
+    source: "Medium",
+  },
+  {
+    title: "Submarine Swap",
+    description:
+      "The era of decentralised trustware — how submarine swaps bridge on-chain Bitcoin and the Lightning Network.",
+    link: "https://medium.com/bitbees/submarine-swap-7ea000b56092",
+    tag: "Lightning",
+    author: "Rajarshi Maitra",
+    date: "Apr 1, 2020",
+    source: "Medium",
+  },
+];
+---
+
+<Layout
+  title="Blogs & Posts"
+  headerProps={headerProps}
+  isVisible={isVisible}
+>
+  <div
+    slot="headerChild"
+    class="mx-auto -mt-16 flex max-w-screen-xl flex-col"
+  >
+    <div slot="after-heading">
+      <h1
+        class="text-center font-header text-4xl font-bold leading-[100%] text-[#F7F7F7] [text-shadow:6px_6px_24px_rgba(0,0,0,0.32)] md:text-6xl lg:text-[124px]"
+      >
+        Blogs & Posts
+      </h1>
+      <p
+        class="mt-3 px-4 text-center text-[18px] font-medium leading-[120%] text-[#F7F7F7] [text-shadow:4px_4px_8px_rgba(0,0,0,0.55)] md:mt-5 md:px-0 md:text-[24px] lg:text-[32px]"
+      >
+        Long-form writing from the Bitshala community and friends —<br
+          class="hidden lg:inline"
+        />
+        deep dives into Bitcoin, wallets, and the ideas shaping the ecosystem.
+      </p>
+    </div>
+  </div>
+
+  <!-- Substack-style feed -->
+  <div class="mx-auto max-w-3xl px-4 py-12 md:px-6 lg:py-20">
+    {
+      posts.map((post, idx) => (
+        <a
+          href={post.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          class={`group block py-8 transition-colors hover:bg-peach/40 ${idx !== posts.length - 1 ? "border-b border-darkPeach/60" : ""}`}
+        >
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1 font-base text-sm text-black/60">
+            <span class="text-black" style="font-weight: 600;">
+              {post.author}
+            </span>
+            <span>·</span>
+            <span>{post.date}</span>
+            <span>·</span>
+            <span>{post.source}</span>
+          </div>
+          <h2 class="mt-3 font-header text-2xl font-bold leading-[1.2] text-black transition-colors group-hover:text-orange md:text-3xl lg:text-[34px]">
+            {post.title}
+          </h2>
+          <p
+            class="mt-3 font-base text-base leading-relaxed text-black/80 md:text-lg"
+            style="font-weight: 400;"
+          >
+            {post.description}
+          </p>
+          <div class="mt-4 flex items-center gap-3">
+            <span class="w-fit rounded-full bg-orange px-3 py-1 font-base text-xs font-bold uppercase tracking-wide text-white">
+              {post.tag}
+            </span>
+            <span
+              class="font-header text-sm text-orange opacity-0 transition-opacity group-hover:opacity-100"
+              style="font-weight: 600;"
+            >
+              Read →
+            </span>
+          </div>
+        </a>
+      ))
+    }
+  </div>
+</Layout>

--- a/src/pages/resources.astro
+++ b/src/pages/resources.astro
@@ -114,10 +114,10 @@ const courses = [
     tag: "Course",
   },
   {
-    title: "Saylor Academy - Bitcoin for Everybody",
+    title: "My First Bitcoin",
     description:
-      "A free, beginner-friendly course covering the basics of Bitcoin, its history, and economic significance.",
-    link: "https://learn.saylor.org/course/PRDV151",
+      "A free, open-source Bitcoin curriculum used by education groups worldwide — beginner-friendly basics of Bitcoin, money, and self-custody.",
+    link: "https://myfirstbitcoin.org/",
     tag: "Free",
   },
   {


### PR DESCRIPTION
- new /blogs page with Substack-style feed (11 posts from the Coin Selection series and Rajarshi Maitra's Medium archive), reusing the cohort hero
- move Resources into the Bitcoin Career submenu and surface Blogs & Posts as a top-level nav item (desktop + mobile)
- replace dead Saylor "Bitcoin for Everybody" link (404) with My First Bitcoin