### PR TITLE
Fix fellowship application URL to include /fellowship path

### DIFF
--- a/src/components/apprenticeship/Instructions.astro
+++ b/src/components/apprenticeship/Instructions.astro
@@ -5,7 +5,7 @@
 <div class="lg:p-8">
   <div id="apply" class="mb-12 mt-20 flex justify-center lg:mt-40">
     <a
-      href="https://app.bitshala.org/applications"
+      href="https://app.bitshala.org/fellowship/applications"
       class="flex w-full items-center justify-center rounded-xl bg-orange p-4 text-center text-[18px] font-bold leading-[120%] text-white hover:bg-white hover:text-orange hover:outline hover:outline-2 hover:outline-orange md:text-[22px] lg:w-1/2 lg:rounded-2xl lg:p-6 lg:text-[28px]"
     >
       Apply for Fellowship


### PR DESCRIPTION
## Summary
- Follow-up to #337: the Apply for Fellowship CTA pointed to `https://app.bitshala.org/applications`; the correct URL is `https://app.bitshala.org/fellowship/applications` (matching the hero button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)