### PR TITLE
Update BOSS luma event link

### DIFF
--- a/src/pages/boss.astro
+++ b/src/pages/boss.astro
@@ -100,7 +100,7 @@ import Navbar from "../components/boss/Navbar.astro";
           class="h-auto w-full max-w-7xl object-contain"
         />
         <a
-          href="https://luma.com/BossWinter26"
+          href="https://luma.com/bitshalaboss"
           target="_blank"
           class="mt-8 inline-block rounded-lg bg-[#662c53] px-10 py-3 font-boss text-2xl transition-colors hover:bg-[#9B6A8C] md:mt-12 md:px-14 md:py-4 md:text-4xl"
         >


### PR DESCRIPTION
## Summary
- Update the BOSS registration link from https://luma.com/BossWinter26 to https://luma.com/bitshalaboss

🤖 Generated with [Claude Code](https://claude.com/claude-code)