### PR TITLE
Tighten fellowship apply button styling

### DIFF
--- a/src/components/apprenticeship/Instructions.astro
+++ b/src/components/apprenticeship/Instructions.astro
@@ -2,11 +2,11 @@
 
 ---
 
-<div class="lg:p-8">
-  <div id="apply" class="mb-12 mt-20 flex justify-center lg:mt-40">
+<div class="lg:px-8">
+  <div id="apply" class="mb-12 mt-6 flex justify-center lg:mt-8">
     <a
       href="https://app.bitshala.org/fellowship/applications"
-      class="flex w-full items-center justify-center rounded-xl bg-orange p-4 text-center text-[18px] font-bold leading-[120%] text-white hover:bg-white hover:text-orange hover:outline hover:outline-2 hover:outline-orange md:text-[22px] lg:w-1/2 lg:rounded-2xl lg:p-6 lg:text-[28px]"
+      class="inline-flex items-center justify-center rounded-xl bg-orange px-8 py-4 text-center text-[26px] font-bold leading-[120%] text-white hover:bg-white hover:text-orange hover:outline hover:outline-2 hover:outline-orange md:text-[30px] lg:rounded-2xl lg:px-12 lg:py-6 lg:text-[36px]"
     >
       Apply for Fellowship
     </a>


### PR DESCRIPTION
## Summary
Design review changes for the "Apply for Fellowship" button on the fellowship page:
- Reduce white space between the offer list and the button (`mt-20 lg:mt-40` → `mt-6 lg:mt-8`, wrapper `lg:p-8` → `lg:px-8`)
- Increase button text size (18/22/28px → 26/30/36px across breakpoints)
- Button now sizes to its label with `px-8 lg:px-12` instead of stretching to `w-full lg:w-1/2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)