### PR TITLE
Update BOSS Summit dates to Oct 26-30 and fix og:title typo

### DIFF
--- a/src/components/boss/Footer.astro
+++ b/src/components/boss/Footer.astro
@@ -57,7 +57,7 @@
             class="h-10 w-10 md:h-12 md:w-12"
           />
           <span class="text-lg md:text-xl"
-            >26 Oct - 31 Oct</span
+            >26 Oct - 30 Oct</span
           >
         </div>
       </div>

--- a/src/pages/boss.astro
+++ b/src/pages/boss.astro
@@ -14,7 +14,7 @@ import Navbar from "../components/boss/Navbar.astro";
     <meta charset="UTF-8" />
     <meta
       name="description"
-      content="Join us Mar 31 - Apr 6, 2026 in Jaipur for a week of Bitcoin Open Source development."
+      content="Join us Oct 26 - 30, 2026 in Jaipur for a week of Bitcoin Open Source development."
     />
     <meta name="viewport" content="width=device-width" />
     <link
@@ -50,11 +50,11 @@ import Navbar from "../components/boss/Navbar.astro";
     <meta property="og:type" content="website" />
     <meta
       property="og:title"
-      content="BOSS Summit 2026 | Bitcoin BOSS Developer Summit | Bitshala"
+      content="BOSS Summit 2026 | Bitcoin OSS Developer Summit | Bitshala"
     />
     <meta
       property="og:description"
-      content="Join us Mar 31 - Apr 6, 2026 in Jaipur for a week of Bitcoin Open Source development. Developers & designers sharing demos, workshops, and working on active GitHub repos."
+      content="Join us Oct 26 - 30, 2026 in Jaipur for a week of Bitcoin Open Source development. Developers & designers sharing demos, workshops, and working on active GitHub repos."
     />
     <meta
       property="og:image"
@@ -80,7 +80,7 @@ import Navbar from "../components/boss/Navbar.astro";
     />
     <meta
       name="twitter:description"
-      content="Join us Mar 31 - Apr 6, 2026 in Jaipur for a week of Bitcoin Open Source development. Developers & designers sharing demos, workshops, and working on active GitHub repos."
+      content="Join us Oct 26 - 30, 2026 in Jaipur for a week of Bitcoin Open Source development. Developers & designers sharing demos, workshops, and working on active GitHub repos."
     />
     <meta
       name="twitter:image"


### PR DESCRIPTION
## Summary
- Update the BOSS page meta description, `og:description`, and `twitter:description` from "Mar 31 - Apr 6, 2026" to "Oct 26 - 30, 2026"
- Fix `og:title` typo: "Bitcoin BOSS Developer Summit" → "Bitcoin OSS Developer Summit" (now matches the Twitter title)
- Update footer date badge from "26 Oct - 31 Oct" to "26 Oct - 30 Oct"

## Notes
- The `og:image` / `twitter:image` still point to `https://bitshala.org/boss/og-image.jpg`, which 404s — social link previews will have no image until a real file is added (not addressed in this PR)
- Date graphics baked into image assets (e.g. `/boss/date.webp`, schedule images) may still need updating separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)