### PR TITLE
Rename Bitplebs Summit to Bitmela in navbar

### DIFF
--- a/src/components/common/Navbar.jsx
+++ b/src/components/common/Navbar.jsx
@@ -19,8 +19,8 @@ const Navbar = () => {
       link: "/boss",
     },
     {
-      name: "Bitplebs Summit",
-      link: "https://bitplebs.in/",
+      name: "Bitmela",
+      link: "https://thebitmela.com/",
     },
     {
       name: "Bitcoin Career",

--- a/src/components/common/hamburger.tsx
+++ b/src/components/common/hamburger.tsx
@@ -88,8 +88,8 @@ const SideMenu = () => {
       subMenu: [],
     },
     {
-      name: "Bitplebs Summit",
-      link: "https://bitplebs.in/",
+      name: "Bitmela",
+      link: "https://thebitmela.com/",
       subMenu: [],
     },
     {


### PR DESCRIPTION
## Summary
- Renames the navbar (desktop + mobile) link from **Bitplebs Summit** to **Bitmela**
- Updates the URL to https://thebitmela.com/

## Test plan
- [ ] Confirm desktop nav shows Bitmela and opens https://thebitmela.com/
- [ ] Confirm mobile hamburger menu shows the same label and link

Made with [Cursor](https://cursor.com)